### PR TITLE
NFC device engagement and CI pipeline alignment

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -43,7 +43,7 @@ systemProp.sonar.host.url=https://sonarcloud.io
 systemProp.sonar.gradle.skipCompile=true
 systemProp.sonar.coverage.jacoco.xmlReportPaths=build/reports/jacoco/testDebugUnitTestCoverage/testDebugUnitTestCoverage.xml,build/reports/jacoco/testReleaseUnitTestCoverage/testReleaseUnitTestCoverage.xml
 systemProp.sonar.projectName=eudi-lib-android-verifier-core
-VERSION_NAME=0.1.0
+VERSION_NAME=0.2.0-SNAPSHOT
 
 SONATYPE_HOST=CENTRAL_PORTAL
 SONATYPE_AUTOMATIC_RELEASE=false

--- a/verifier-core/src/main/java/eu/europa/ec/eudi/verifier/core/transfer/TransferManager.kt
+++ b/verifier-core/src/main/java/eu/europa/ec/eudi/verifier/core/transfer/TransferManager.kt
@@ -48,12 +48,12 @@ interface TransferManager {
      * @param nfcAdapter The NFC adapter to use.
      * @param activity The activity context for NFC operations.
      */
-    fun enableNFCDeviceEngagement(nfcAdapter: NfcAdapter, activity: Activity)
+    fun enableNFCDeviceEngagement(activity: Activity)
 
     /**
      * Disables NFC device engagement.
      */
-    fun disableNFCDeviceEngagement()
+    fun disableNFCDeviceEngagement(activity: Activity)
 
     /**
      * Sends a request to the holder device.

--- a/verifier-core/src/main/java/eu/europa/ec/eudi/verifier/core/transfer/TransferManagerImpl.kt
+++ b/verifier-core/src/main/java/eu/europa/ec/eudi/verifier/core/transfer/TransferManagerImpl.kt
@@ -39,15 +39,10 @@ class TransferManagerImpl(
     private val context: Context,
     private val config: TransferConfig,
     var logger: Logger? = null,
-    private val verificationHelperFactory: (Context, VerificationHelper.Listener, Executor, DataTransportOptions, List<MdocConnectionMethod>?) -> VerificationHelper = { ctx, listener, executor, options, connectionMethods ->
-        val builder = VerificationHelper.Builder(ctx, listener, executor)
+    private val verificationHelperFactory: (Context, VerificationHelper.Listener, Executor, DataTransportOptions) -> VerificationHelper = { ctx, listener, executor, options ->
+        VerificationHelper.Builder(ctx, listener, executor)
             .setDataTransportOptions(options)
-
-        connectionMethods?.let {
-            builder.setNegotiatedHandoverConnectionMethods(it)
-        }
-
-        builder.build()
+            .build()
     }
 ) : TransferManager {
 
@@ -69,6 +64,7 @@ class TransferManagerImpl(
 
         override fun onDeviceEngagementReceived(connectionMethods: List<MdocConnectionMethod>) {
             logger?.d(TAG, "Device Engagement Received")
+            logger?.d(TAG, "ConnectionMethods $connectionMethods")
 
             transferEventListener?.onEvent(TransferEvent.Connecting)
 
@@ -77,7 +73,10 @@ class TransferManagerImpl(
                 MdocRole.MDOC_READER
             )
 
+            // TODO maybe combine with core's engagementMethods
+
             if (availableMdocConnectionMethods.isNotEmpty()) {
+                // Check condition of verifier vs wallet to pick instead of first()
                 verificationHelper?.connect(availableMdocConnectionMethods.first())
             } else {
                 onError(IllegalStateException("No mdoc connection method selected"))
@@ -88,6 +87,9 @@ class TransferManagerImpl(
         override fun onError(error: Throwable) {
             logger?.e(TAG, "Error: ${error.message}", error)
             transferEventListener?.onEvent(TransferEvent.Error(error))
+            if (error is android.nfc.TagLostException) {
+                return
+            }
             stopSession()
         }
 
@@ -155,8 +157,7 @@ class TransferManagerImpl(
             context,
             responseListener,
             context.mainExecutor(),
-            options,
-            null
+            options
         )
 
         verificationHelper?.setDeviceEngagementFromQrCode(qrCode)
@@ -164,22 +165,18 @@ class TransferManagerImpl(
 
     override fun enableNFCDeviceEngagement(activity: Activity) {
 
+        // TODO config.engagementMethods -> MdocConnectionMethods to determine transaction via Ble or NFC
+
         val options = DataTransportOptions.Builder()
             .setBleUseL2CAP(config.bleUseL2CAP)
             .setBleClearCache(config.bleClearCache)
             .build()
 
-        val negotiatedConnectionMethods = config.engagementMethods.getOrDefault(
-            TransferConfig.EngagementMethod.NFC,
-            emptyList()
-        )
-
         verificationHelper = verificationHelperFactory(
             context,
             responseListener,
             context.mainExecutor(),
-            options,
-            negotiatedConnectionMethods
+            options
         )
 
         val adapter = NfcAdapter.getDefaultAdapter(context)

--- a/verifier-core/src/main/java/eu/europa/ec/eudi/verifier/core/transfer/TransferManagerImpl.kt
+++ b/verifier-core/src/main/java/eu/europa/ec/eudi/verifier/core/transfer/TransferManagerImpl.kt
@@ -26,7 +26,6 @@ import eu.europa.ec.eudi.verifier.core.logging.Logger
 import eu.europa.ec.eudi.verifier.core.logging.d
 import eu.europa.ec.eudi.verifier.core.logging.e
 import eu.europa.ec.eudi.verifier.core.request.DeviceRequest
-import eu.europa.ec.eudi.verifier.core.request.Request
 import eu.europa.ec.eudi.verifier.core.response.DeviceResponse
 import org.multipaz.cbor.Cbor
 import org.multipaz.crypto.Algorithm
@@ -40,10 +39,15 @@ class TransferManagerImpl(
     private val context: Context,
     private val config: TransferConfig,
     var logger: Logger? = null,
-    private val verificationHelperFactory: (Context, VerificationHelper.Listener, Executor, DataTransportOptions) -> VerificationHelper = { ctx, listener, executor, options ->
-        VerificationHelper.Builder(ctx, listener, executor)
+    private val verificationHelperFactory: (Context, VerificationHelper.Listener, Executor, DataTransportOptions, List<MdocConnectionMethod>?) -> VerificationHelper = { ctx, listener, executor, options, connectionMethods ->
+        val builder = VerificationHelper.Builder(ctx, listener, executor)
             .setDataTransportOptions(options)
-            .build()
+
+        connectionMethods?.let {
+            builder.setNegotiatedHandoverConnectionMethods(it)
+        }
+
+        builder.build()
     }
 ) : TransferManager {
 
@@ -151,18 +155,62 @@ class TransferManagerImpl(
             context,
             responseListener,
             context.mainExecutor(),
-            options
+            options,
+            null
         )
 
         verificationHelper?.setDeviceEngagementFromQrCode(qrCode)
     }
 
-    override fun enableNFCDeviceEngagement(nfcAdapter: NfcAdapter, activity: Activity) {
-        logger?.d(TAG, "Not implemented yet")
+    override fun enableNFCDeviceEngagement(activity: Activity) {
+
+        val options = DataTransportOptions.Builder()
+            .setBleUseL2CAP(config.bleUseL2CAP)
+            .setBleClearCache(config.bleClearCache)
+            .build()
+
+        val negotiatedConnectionMethods = config.engagementMethods.getOrDefault(
+            TransferConfig.EngagementMethod.NFC,
+            emptyList()
+        )
+
+        verificationHelper = verificationHelperFactory(
+            context,
+            responseListener,
+            context.mainExecutor(),
+            options,
+            negotiatedConnectionMethods
+        )
+
+        val adapter = NfcAdapter.getDefaultAdapter(context)
+        if (adapter == null) {
+            val error = IllegalStateException("NFC is not available on this device.")
+            logger?.e(TAG, error.message.toString())
+            transferEventListener?.onEvent(TransferEvent.Error(error))
+            return
+        }
+
+        adapter.enableReaderMode(
+            activity,
+            { tag ->
+                verificationHelper?.nfcProcessOnTagDiscovered(tag)
+                logger?.d(TAG, "NFC Tag Discovered: $tag")
+            },
+            NfcAdapter.FLAG_READER_NFC_A + NfcAdapter.FLAG_READER_NFC_B
+                    + NfcAdapter.FLAG_READER_SKIP_NDEF_CHECK + NfcAdapter.FLAG_READER_NO_PLATFORM_SOUNDS,
+            null
+        )
     }
 
-    override fun disableNFCDeviceEngagement() {
-        logger?.d(TAG, "Not implemented yet")
+    /**
+     * Disables NFC engagement for the given Activity.
+     * This MUST be called from the Activity's onPause().
+     * @param activity The activity that previously enabled reader mode.
+     */
+    override fun disableNFCDeviceEngagement(activity: Activity) {
+        logger?.d(TAG, "Disabling NFC Reader Mode for Activity: ${activity.javaClass.simpleName}")
+        val nfcAdapter = NfcAdapter.getDefaultAdapter(activity)
+        nfcAdapter?.disableReaderMode(activity)
     }
 
     override fun sendRequest(request: DeviceRequest) {

--- a/verifier-core/src/test/java/eu/europa/ec/eudi/verifier/core/transfer/TransferManagerImplTest.kt
+++ b/verifier-core/src/test/java/eu/europa/ec/eudi/verifier/core/transfer/TransferManagerImplTest.kt
@@ -20,7 +20,7 @@ class TransferManagerImplTest {
     private lateinit var transferManager: TransferManagerImpl
     private lateinit var executor: Executor
     private lateinit var listener: TransferEvent.Listener
-    private lateinit var verificationHelperFactory: (Context, VerificationHelper.Listener, Executor, DataTransportOptions, List<MdocConnectionMethod>?) -> VerificationHelper
+    private lateinit var verificationHelperFactory: (Context, VerificationHelper.Listener, Executor, DataTransportOptions) -> VerificationHelper
     private lateinit var capturedVerificationListener: VerificationHelper.Listener
 
     @BeforeTest
@@ -36,7 +36,7 @@ class TransferManagerImplTest {
         listener = mockk(relaxed = true)
 
         // Capture the VerificationHelper.Listener for use in tests
-        verificationHelperFactory = { _, l, _, _, _->
+        verificationHelperFactory = { _, l, _, _->
             capturedVerificationListener = l
             verificationHelper
         }

--- a/verifier-core/src/test/java/eu/europa/ec/eudi/verifier/core/transfer/TransferManagerImplTest.kt
+++ b/verifier-core/src/test/java/eu/europa/ec/eudi/verifier/core/transfer/TransferManagerImplTest.kt
@@ -10,6 +10,7 @@ import java.util.concurrent.Executor
 import org.multipaz.mdoc.request.DeviceRequestGenerator
 import eu.europa.ec.eudi.verifier.core.request.DeviceRequest
 import eu.europa.ec.eudi.verifier.core.request.DocRequest
+import org.multipaz.mdoc.connectionmethod.MdocConnectionMethod
 
 class TransferManagerImplTest {
     private lateinit var context: Context
@@ -19,7 +20,7 @@ class TransferManagerImplTest {
     private lateinit var transferManager: TransferManagerImpl
     private lateinit var executor: Executor
     private lateinit var listener: TransferEvent.Listener
-    private lateinit var verificationHelperFactory: (Context, VerificationHelper.Listener, Executor, DataTransportOptions) -> VerificationHelper
+    private lateinit var verificationHelperFactory: (Context, VerificationHelper.Listener, Executor, DataTransportOptions, List<MdocConnectionMethod>?) -> VerificationHelper
     private lateinit var capturedVerificationListener: VerificationHelper.Listener
 
     @BeforeTest
@@ -35,7 +36,7 @@ class TransferManagerImplTest {
         listener = mockk(relaxed = true)
 
         // Capture the VerificationHelper.Listener for use in tests
-        verificationHelperFactory = { _, l, _, _ ->
+        verificationHelperFactory = { _, l, _, _, _->
             capturedVerificationListener = l
             verificationHelper
         }


### PR DESCRIPTION
- Implement NFC device engagement via enableNFCDeviceEngagement and disableNFCDeviceEngagement (previously stubs returning "Not implemented yet")
- Simplify verificationHelperFactory by removing the connectionMethods parameter — negotiated handover connection methods are deferred for rework 
- Handle TagLostException gracefully by propagating the error event without terminating the session
- Bump VERSION_NAME to 0.2.0-SNAPSHOT